### PR TITLE
Fix LCG counter never getting initialized

### DIFF
--- a/data/random/functions/private/load.mcfunction
+++ b/data/random/functions/private/load.mcfunction
@@ -12,7 +12,7 @@
 
 # Create scoreboard objective and initialise LCG
 scoreboard objectives add random dummy
-execute store result score #lcg_x random run seed
+execute unless score #lcg random = #lcg random store result score #lcg random run seed
 
 # Define constants
 scoreboard players set #3 random 3


### PR DESCRIPTION
The current pack sets `#lcg_x` to the result of `seed` every time the pack is loaded. However, `#lcg_x` is never used; the actual LCG counter variable is named `#lcg`. Since `#lcg` is never explicitly initialized, it is left to be default-initialized to 0 the first time the LCG is used.

This fix stores the seed into the correct score name, and only sets it once.